### PR TITLE
Fix thermostat button in Firefox

### DIFF
--- a/assets/css/thermostat.css
+++ b/assets/css/thermostat.css
@@ -178,7 +178,7 @@
   color: #b9b6c8;
   font-size: 60px;
   font-weight: 500;
-  line-height: 260px;
+  margin-top: 111px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Without this fix, uncommenting 'background: none' shows that the
background of the button is rendered in a different spot than the + or
-, and while the background is clickable, the button text isn't.

![screen shot 2019-03-08 at 11 13 10 am](https://user-images.githubusercontent.com/338814/54040383-31063880-4193-11e9-8e92-6b764a7a54a2.png)

The fix moves the background along with the text so that it's clickable in Firefox