### PR TITLE
Correct phoenix_live_view dependency for assets

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5794,7 +5794,7 @@
       "version": "file:../deps/phoenix_html"
     },
     "phoenix_live_view": {
-      "version": "file:../../../oss/phoenix_live_view"
+      "version": "file:../deps/phoenix_live_view"
     },
     "pify": {
       "version": "3.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "phoenix": "../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
-    "phoenix_live_view": "file:~/oss/phoenix_live_view"
+    "phoenix_live_view": "file:../deps/phoenix_live_view"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
This change corrects the dependency paths for the assets to point to the project's dependencies instead of the `~/oss/phoenix_live_view` directory.