### PR TITLE
Fixes PresenceIndex's delete_user handle_event action

### DIFF
--- a/lib/demo_web/live/user_live/presence_index.ex
+++ b/lib/demo_web/live/user_live/presence_index.ex
@@ -29,7 +29,7 @@ defmodule DemoWeb.UserLive.PresenceIndex do
     {:noreply, fetch(socket)}
   end
 
-  def handle_event("delete_user", _, id, socket) do
+  def handle_event("delete_user", id, socket) do
     user = Accounts.get_user!(id)
     {:ok, _user} = Accounts.delete_user(user)
 


### PR DESCRIPTION
PhoenixLiveView handle_event appears to have an arity of 3, where the first argument is the event, the second is params, and third is the socket. The DemoWeb.UserLive.PresenceIndex handle_event expected 4 arguments, but now expects 3.