### PR TITLE
Use form_for/3 when integrating forms with LiveView

### DIFF
--- a/lib/demo_web/templates/user/form.html.leex
+++ b/lib/demo_web/templates/user/form.html.leex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, "#", [phx_change: :validate, phx_submit: :save], fn f -> %>
+<%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :save] %>
   <%= if @changeset.action do %>
     <!-- <div class="alert alert-danger"> -->
     <!--   <p>Oops, something went wrong! Please check the errors below.</p> -->
@@ -20,4 +20,4 @@
   <div>
     <%= submit "Save", phx_disable_with: "Saving..." %>
   </div>
-<% end %>
+</form>


### PR DESCRIPTION
The documentation for `Phoenix.HTML.Form` suggests using `form_for/3` instead of `form_form/4`, when integrating LiveView with forms.

See docs: [Phoenix.HTML.Form#form_form/3](https://github.com/phoenixframework/phoenix_html/blob/4826c4dd3b83e86189aae1a6492cd622ddfb1653/lib/phoenix_html/form.ex#L185-L205)