### PR TITLE
Move Phoenix.LiveView.Controller alias as an import

### DIFF
--- a/lib/demo_web.ex
+++ b/lib/demo_web.ex
@@ -23,6 +23,7 @@ defmodule DemoWeb do
 
       import Plug.Conn
       import DemoWeb.Gettext
+      import Phoenix.LiveView.Controller, only: [live_render: 3]
       alias DemoWeb.Router.Helpers, as: Routes
     end
   end

--- a/lib/demo_web/controllers/page_controller.ex
+++ b/lib/demo_web/controllers/page_controller.ex
@@ -1,8 +1,6 @@
 defmodule DemoWeb.PageController do
   use DemoWeb, :controller
 
-  alias Phoenix.LiveView
-
   def index(conn, _params) do
     render(conn, "index.html")
   end
@@ -10,6 +8,6 @@ defmodule DemoWeb.PageController do
   def snake(conn, _) do
     conn
     |> put_layout(:game)
-    |> LiveView.Controller.live_render(DemoWeb.SnakeLive, session: %{})
+    |> live_render(DemoWeb.SnakeLive, session: %{})
   end
 end


### PR DESCRIPTION
Based on question posed here
https://github.com/phoenixframework/phoenix/pull/3376#discussion_r275772263

And a separate PR into the LiveView documentation here
https://github.com/phoenixframework/phoenix_live_view/pull/198

I am updating the examples to use the approach to import the live_render instead of using an alias