### PR TITLE
Simpler user phone number regex

### DIFF
--- a/lib/demo/accounts/user.ex
+++ b/lib/demo/accounts/user.ex
@@ -10,7 +10,7 @@ defmodule Demo.Accounts.User do
     timestamps()
   end
 
-  @phone ~r/^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}$/
+  @phone ~r/\s?\+?[0-9.\-\s]+\s?$/
 
   @doc false
   def changeset(user, attrs) do


### PR DESCRIPTION
The existing phone number validation is impossible to get past if you don't know the format required. As this is a demo, I think the format could be simplified, in order to allow more people to play with the form. 