### PR TITLE
demo select bug

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.8.2-otp-21
+erlang 21.3.8.6

--- a/lib/demo/accounts/user.ex
+++ b/lib/demo/accounts/user.ex
@@ -6,6 +6,8 @@ defmodule Demo.Accounts.User do
     field :username, :string
     field :email, :string
     field :phone_number, :string
+    field :foo, :string, virtual: true
+    field :bar, :string, virtual: true
 
     timestamps()
   end
@@ -15,7 +17,7 @@ defmodule Demo.Accounts.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:username, :email, :phone_number])
+    |> cast(attrs, [:username, :email, :phone_number, :foo, :bar])
     |> validate_required([:username, :email, :phone_number])
     |> validate_format(:username, ~r/^[a-zA-Z0-9_]*$/,
       message: "only letters, numbers, and underscores please"

--- a/lib/demo_web/live/user_live/new.ex
+++ b/lib/demo_web/live/user_live/new.ex
@@ -7,6 +7,10 @@ defmodule DemoWeb.UserLive.New do
   alias Demo.Accounts.User
 
   def mount(_session, socket) do
+    socket =
+      socket
+      |> assign(:options, [[key: "A", value: "a"], [key: "B", value: "b"]])
+
     {:ok,
      assign(socket, %{
        changeset: Accounts.change_user(%User{})
@@ -19,6 +23,7 @@ defmodule DemoWeb.UserLive.New do
     changeset =
       %User{}
       |> Demo.Accounts.change_user(params)
+      |> Ecto.Changeset.change(bar: params["foo"])
       |> Map.put(:action, :insert)
 
     {:noreply, assign(socket, changeset: changeset)}

--- a/lib/demo_web/templates/user/form.html.leex
+++ b/lib/demo_web/templates/user/form.html.leex
@@ -17,6 +17,11 @@
   <%= text_input f, :phone_number %>
   <%= error_tag f, :phone_number %>
 
+  <%= select f, :foo, @options %>
+
+  <%= text_input f, :bar %>
+  <%= select f, :bar, @options %>
+
   <div>
     <%= submit "Save", phx_disable_with: "Saving..." %>
   </div>


### PR DESCRIPTION
I have added `:foo` and `:bar` virtual columns to User. In the form, `:foo` is controlled by a selector with options `A => a, B => b`.

Also in the form, `:bar` is displayed with both a text field and a selector with the same options.

![image](https://user-images.githubusercontent.com/247817/63095523-75afb000-bf39-11e9-9f28-f02757994a28.png)

When I click on the selector to make a change to `:foo`, the `validate` callback in the live view also makes a change to `:bar` to set it the same as `:foo`: https://github.com/chrismccord/phoenix_live_view_example/pull/39/files#diff-ba686f7f18e067a11567b119ec1695e5R26

This is reflected in the `:bar` text field, but the `:bar` select tag does NOT change. If you IO.inspect the rendered form, you'll find that it is not sending `selected` on that option row for some reason.

![image](https://user-images.githubusercontent.com/247817/63095748-fec6e700-bf39-11e9-900d-ead682b04cd1.png)

This seems like a bug, since it makes it impossible to control select values from the backend. I'm happy to look into it but I'm having trouble finding where that logic exists.