### PR TITLE
Get users demo working again

### DIFF
--- a/lib/demo_web/live/user_live/edit.ex
+++ b/lib/demo_web/live/user_live/edit.ex
@@ -5,18 +5,18 @@ defmodule DemoWeb.UserLive.Edit do
   alias DemoWeb.Router.Helpers, as: Routes
   alias Demo.Accounts
 
-  def mount(%{path_params: %{"id" => id}}, socket) do
-    user = Accounts.get_user!(id)
-
-    {:ok,
-     assign(socket, %{
-       count: 0,
-       user: user,
-       changeset: Accounts.change_user(user)
-     })}
+  def mount(_session, socket) do
+    {:ok, assign(socket, count: 0)}
   end
 
   def render(assigns), do: DemoWeb.UserView.render("edit.html", assigns)
+
+  def handle_params(%{"id" => id} = _params, _url, socket) do
+    user = Accounts.get_user!(id)
+    changeset = Accounts.change_user(user)
+    socket = assign(socket, user: user, changeset: changeset)
+    {:noreply, socket}
+  end
 
   def handle_event("validate", %{"user" => params}, socket) do
     changeset =
@@ -30,7 +30,7 @@ defmodule DemoWeb.UserLive.Edit do
   def handle_event("save", %{"user" => user_params}, socket) do
     case Accounts.update_user(socket.assigns.user, user_params) do
       {:ok, user} ->
-        {:stop,
+        {:noreply,
          socket
          |> put_flash(:info, "User updated successfully.")
          |> redirect(to: Routes.live_path(socket, UserLive.Show, user))}

--- a/lib/demo_web/live/user_live/index.ex
+++ b/lib/demo_web/live/user_live/index.ex
@@ -11,7 +11,7 @@ defmodule DemoWeb.UserLive.Index do
     {:ok, assign(socket, page: 1, per_page: 5)}
   end
 
-  def handle_params(params, url, socket) do
+  def handle_params(params, _url, socket) do
     {page, ""} = Integer.parse(params["page"] || "1")
     {:noreply, socket |> assign(page: page) |> fetch()}
   end
@@ -33,15 +33,15 @@ defmodule DemoWeb.UserLive.Index do
   end
   def handle_event("keydown", _, socket), do: {:noreply, socket}
 
-  defp go_page(socket, page) when page > 0 do
-    live_redirect(socket, to: Routes.live_path(socket, __MODULE__, page))
-  end
-  defp go_page(socket, page), do: socket
-
   def handle_event("delete_user", id, socket) do
     user = Accounts.get_user!(id)
     {:ok, _user} = Accounts.delete_user(user)
 
     {:noreply, socket}
   end
+
+  defp go_page(socket, page) when page > 0 do
+    live_redirect(socket, to: Routes.live_path(socket, __MODULE__, page))
+  end
+  defp go_page(socket, _page), do: socket
 end

--- a/lib/demo_web/live/user_live/new.ex
+++ b/lib/demo_web/live/user_live/new.ex
@@ -13,7 +13,7 @@ defmodule DemoWeb.UserLive.New do
 
   def render(assigns), do: Phoenix.View.render(DemoWeb.UserView, "new.html", assigns)
 
-  def handle_event("validate", %{"user" => user_params} = params, socket) do
+  def handle_event("validate", %{"user" => user_params} = _params, socket) do
     changeset =
       %User{}
       |> Demo.Accounts.change_user(user_params)
@@ -22,7 +22,7 @@ defmodule DemoWeb.UserLive.New do
     {:noreply, assign(socket, changeset: changeset)}
   end
 
-  def handle_event("save", %{"user" => user_params} = params, socket) do
+  def handle_event("save", %{"user" => user_params} = _params, socket) do
     case Accounts.create_user(user_params) do
       {:ok, user} ->
         {:stop,

--- a/lib/demo_web/live/user_live/show.ex
+++ b/lib/demo_web/live/user_live/show.ex
@@ -20,9 +20,16 @@ defmodule DemoWeb.UserLive.Show do
     """
   end
 
-  def mount(%{path_params: %{"id" => id}}, socket) do
+  def mount(_session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(%{"id" => id} = _params, _url, socket) do
     if connected?(socket), do: Demo.Accounts.subscribe(id)
-    {:ok, fetch(assign(socket, id: id))}
+    user = Accounts.get_user!(id)
+    changeset = Accounts.change_user(user)
+    socket = assign(socket, user: user, changeset: changeset)
+    {:noreply, socket}
   end
 
   defp fetch(%Socket{assigns: %{id: id}} = socket) do


### PR DESCRIPTION
Updates the users demo to use the newer `handle_params/3` callback instead of the obsolete `:path_params` value in the `mount/2` callback.

Also fix Elixir warnings.