### PR TITLE
Bring back the simple counter demo

### DIFF
--- a/lib/demo_web/live/counter_live.ex
+++ b/lib/demo_web/live/counter_live.ex
@@ -1,52 +1,19 @@
-defmodule DemoWeb.CountersLive do
-  use Phoenix.LiveView
-
-  def render(assigns) do
-    ~L"""
-    <%= inspect(@counters) %>
-    <button phx-click="shuffle">shufftle</button>
-    <%= for {{id, count}, index} <- Enum.with_index(@counters) do %>
-      <%= if index == 0 do %>
-        <blockquote>
-          <div>
-            <pre>
-              <%= id %><%= live_render(@socket, DemoWeb.CounterLive, id: "counter-#{id}", session: %{val: count}) %>
-            <pre>
-          <div>
-        </blockquote>
-      <% else %>
-        <%= id %><%= live_render(@socket, DemoWeb.CounterLive, id: "counter-#{id}", session: %{val: count}) %>
-      <% end %>
-    <% end %>
-    """
-  end
-
-  def mount(_session, socket) do
-    {:ok, assign(socket, counters: [{1, 1}, {2, 2}, {3, 3}])}
-  end
-
-  def handle_event("shuffle", _, socket) do
-    {:noreply, assign(socket, counters: IO.inspect(Enum.shuffle(socket.assigns.counters)))}
-  end
-end
-
 defmodule DemoWeb.CounterLive do
   use Phoenix.LiveView
 
   def render(assigns) do
     ~L"""
     <div>
-      <h1 phx-click="boom">The count is: <span id="val" phx-hook="Count" phx-update="ignore"><%= @val %></a></h1>
-      <%= @val %>
+      <h1>The count is: <%= @val %></h1>
       <button phx-click="boom" class="alert-danger">BOOM</button>
       <button phx-click="dec">-</button>
-      <button phx-click="inc" phx-debounce="1000">+</button>
+      <button phx-click="inc">+</button>
     </div>
     """
   end
 
   def mount(session, socket) do
-    {:ok, assign(socket, :val, session[:val] || 0)}
+    {:ok, assign(socket, :val, 0)}
   end
 
   def handle_event("inc", _, socket) do

--- a/lib/demo_web/router.ex
+++ b/lib/demo_web/router.ex
@@ -28,7 +28,6 @@ defmodule DemoWeb.Router do
     live "/pacman", PacmanLive
     live "/rainbow", RainbowLive
     live "/counter", CounterLive
-    live "/counters", CountersLive
     live "/top", TopLive
     live "/presence_users/:name", UserLive.PresenceIndex
 


### PR DESCRIPTION
Seems like the last commit to this file changed it with some temporary (?) code. The counter demo seems one of the most fundamental ones and is referenced in the "Programming Phoenix 1.4" book that I think it should stay as simple as it can be.

The "Counters" demo is not linked to on the main website. And the debounce makes the demo feel that something is broken.

Feel free to close if I misunderstood the author's intention.