### PR TITLE
[Weather Demo] Re-URI.encode city name

### DIFF
--- a/lib/demo_web/live/weather_live.ex
+++ b/lib/demo_web/live/weather_live.ex
@@ -31,7 +31,7 @@ defmodule DemoWeb.WeatherLive do
 
   defp weather(local) do
     {:ok, {{_, 200, _}, _, body}} =
-      :httpc.request(:get, {~c"http://wttr.in/#{local}?format=1", []}, [], [])
+      :httpc.request(:get, {~c"http://wttr.in/#{URI.encode(local)}?format=1", []}, [], [])
     IO.iodata_to_binary(body)
   end
 end


### PR DESCRIPTION
Prior to this commit the weather example fails for cities which have
characters which must be `URI.encode`d in order to be represented in a
URL, e.g. "Düsseldorf", "Kraków", "Malmö", "Tromsø". This commit adds a
call to `URI.encode` before passing the city name along to `wttr.in`.