### PR TITLE
Rename socket assign @live_view_module to @live_module

### DIFF
--- a/lib/demo_web/templates/layout/live.html.leex
+++ b/lib/demo_web/templates/layout/live.html.leex
@@ -5,7 +5,7 @@
 <hr/>
 
 <div id="main">
-  <%= @live_view_module.render(assigns) %>
+  <%= @live_module.render(assigns) %>
 </div>
 
 


### PR DESCRIPTION
According to the [phoenix_live_view 0.10.0 changelog](https://github.com/phoenixframework/phoenix_live_view/blob/c05547d97d3831eea5066e74d38d4e6b23e0c539/CHANGELOG.md#backwards-incompatible-changes) live_view_module was renamed to live_module.