### PR TITLE
Removed readme Guides link that returned 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Ready to run in production? Please [check our deployment guides](https://hexdocs
 ## Learn more
 
   * Official website: https://www.phoenixframework.org/
-  * Guides: https://phoenixframework.org/docs/overview
-  * Docs: https://hexdocs.pm/phoenix
+  * Docs and Guides: https://hexdocs.pm/phoenix
   * Mailing list: https://groups.google.com/group/phoenix-talk
   * Source: https://github.com/phoenixframework/phoenix


### PR DESCRIPTION
The Guides link in the readme pointed to `https://phoenixframework.org/docs/overview` which returned a 404. However clicking the "Guides" link from the `https://phoenixframework.org/` page navigates to the same page as the Docs link in the readme. In order to correct this I removed the Guides link and updated the Docs label to indicate that both Docs and Guides are found on the same Hex PM Overview page.

Also I found this 404 issue when browsing this repo after reading Programming Phoenix 1.4. I really, really enjoyed the book! Thanks for writing it and providing so many awesome examples.