### PR TITLE
Make the intentional theromostat demo error obviouse

### DIFF
--- a/lib/demo_web/live/thermostat_live.ex
+++ b/lib/demo_web/live/thermostat_live.ex
@@ -30,7 +30,7 @@ defmodule DemoWeb.ThermostatLive do
   end
 
   def handle_event("inc", _, socket) do
-    if socket.assigns.val >= 75, do: raise("boom")
+    if socket.assigns.val >= 75, do: raise("Intentional error to demonstrate recovery")
     {:noreply, update(socket, :val, &(&1 + 1))}
   end
 


### PR DESCRIPTION
The thermostat demo in this repo contains an intentional error to show how the app will recover after an error. The current exception message is `boom` which is confusing for the uninitiated folks such as myself 🙂 

This PR changes the exception message to `Intentional error to demonstrate recovery` to be more obvious to make it easy to see from the server log what the error is about.